### PR TITLE
Resolve font bug on Android

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -1,5 +1,5 @@
 // @flow
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 // const eventPaddingLeft = 4
 const leftMargin = 50 - 1;
@@ -102,7 +102,7 @@ export default function styleConstructor(theme = {}, calendarHeight) {
       left: 15,
       color: 'rgb(170,170,170)',
       fontSize: 10,
-      fontFamily: 'Helvetica Neue',
+      fontFamily: Platform.OS == 'ios' ? 'Helvetica Neue' : 'Roboto',
       fontWeight: '500',
       ...theme.timeLabel,
     },


### PR DESCRIPTION
On Android there's not an Helvetica Neue font but it uses Roboto as system font.
Update the style to check the platform and loading the correct font based on it.
Is this ok for you?